### PR TITLE
Skip disabled distributions early

### DIFF
--- a/lib/CPAN/Reporter/Smoker.pm
+++ b/lib/CPAN/Reporter/Smoker.pm
@@ -163,6 +163,11 @@ sub start {
           "Smoker: already tested $base [$count]\n");
         next DIST;
       }
+      elsif ( CPAN::Distribution->new(%{$dist})->prefs->{disabled} ) {
+        $CPAN::Frontend->mywarn(
+          "Smoker: dist disabled $base [$count]\n");
+        next DIST;
+      }
       else {
         # record distribution being smoked
         my $time = scalar localtime();

--- a/t/data/disabled.yml
+++ b/t/data/disabled.yml
@@ -1,0 +1,5 @@
+---
+comment: "Don't build mod_perl if required by some other module"
+match:
+    distribution: "/Bogus-"
+disabled: 1

--- a/t/lib/CPAN/MyConfig.pm
+++ b/t/lib/CPAN/MyConfig.pm
@@ -2,11 +2,13 @@
 use Cwd;
 my $cwd = cwd;
 my $Iswin = $^O eq "MSWin32";
+my $is_disable_test = $ENV{IS_DISABLE_TEST};
 $CPAN::Config = {
                  $Iswin ? () : (
                                 'make_install_make_command' => q[make],
                                 'mbuild_install_build_command' => q[./Build],
                                ),
+                 $is_disable_test ? ( 'prefs_dir' => qq[$cwd/t/data] ) : (),
                  'auto_commit' => 0,
                  'build_cache' => q[100],
                  'build_dir' => qq[$cwd/t/dot-cpan/build],

--- a/t/smoke-disabled.t
+++ b/t/smoke-disabled.t
@@ -21,6 +21,8 @@ $ENV{PERL5LIB} = join( $Config{path_sep},
     $test_lib, ( defined $ENV{PERL5LIB} ? $ENV{PERL5LIB} : () )
 );
 
+$ENV{IS_DISABLE_TEST} = 1;
+
 # Force load early so the testing version will be found before CPAN.pm
 # adds $ENV{HOME}/.cpan to @INC so we don't load the user's config by mistake
 require CPAN::MyConfig;
@@ -57,4 +59,4 @@ else {
 
 require_ok( 'CPAN::Reporter::History' );
 my @results = CPAN::Reporter::History::have_tested();
-is( scalar @results, 6, "Number of reports in history" );
+is( scalar @results, 1, "Number of reports in history" );


### PR DESCRIPTION
As discussed in the IRC channel, this channel will make it possible for smoker to skip disabled distributions without loading a completely new instance of CPAN. This will speed up smoker restarts (for whatever reason) massively.
