### PR TITLE
Added statistics generation and "live" monitor

### DIFF
--- a/bin/show_progress.pl
+++ b/bin/show_progress.pl
@@ -4,33 +4,59 @@ use warnings;
 use strict;
 use IO::Socket;
 use Storable qw(thaw);
+use Getopt::Std;
 use constant MY_ECHO_PORT => 2007;
 use constant MAX_MSG_LEN => 5000;
 
-my $port = shift || MY_ECHO_PORT;
+my %opts;
+getopts('hp:l:',\%opts);
+
+if (exists($opts{h})) {
+    print <<BLOCK;
+Small UDP server to receive notification of CPAN::Reporter smokers.
+Usage:
+-h: this help message
+-p: port to listen to (default to 2007)
+-l: local address to bind to (default to "localhost")
+BLOCK
+    exit 0;
+}
+
+my ($port,$local_addr);
+
+if (exists($opts{p})) {
+    $port = $opts{p};
+} else {
+    $port = 2007;
+}
+
+if (exists($opts{l})) {
+    $local_addr = $opts{l};
+} else {
+    $local_addr = 'localhost';
+}
 
 $SIG{INT} = sub { exit 0 };
 
-my $sock = IO::Socket::INET->new(Proto => 'udp', LocalPort => $port) or die $@;
-
-my $msg_in;
+my $sock = IO::Socket::INET->new(Proto => 'udp', LocalPort => $port, LocalAddr => $local_addr) or die $@;
 
 warn "servicing incoming requests...\n";
 
 while(1) {
 
+    my $msg_in;
     next unless $sock->recv($msg_in, MAX_MSG_LEN);
     my $status_ref = thaw($msg_in);
     my $peer_host = gethostbyaddr($sock->peeraddr, AF_INET) || $sock->peerhost;
     my $peer_port = $sock->peerport;
     my $length = length($msg_in);
 
-    my ($curr_dists, $total_dists, $dps) = ( $status_ref->{curr_dists},$status_ref->{total_dists},$status_ref->{dps} );
+    my ($curr_dists, $total_dists, $dpm) = ( $status_ref->{curr_dists},$status_ref->{total_dists},$status_ref->{dpm} );
 
     print '+----------------------------------------+', "\n";
     print 'CPAN::Reporter::Smoker quick stats:', "\n";
     print "Received $length bytes from [$peer_host, $peer_port]\n";
-    print "Doing $curr_dists of $total_dists ($dps)\n";
+    print "Doing $curr_dists of $total_dists ($dpm)\n";
 
     #$msg_out = reverse $msg_in;
     #$sock->send($msg_out) or die "send(): $!\n";

--- a/bin/show_progress.pl
+++ b/bin/show_progress.pl
@@ -1,0 +1,40 @@
+#!/usr/bin/env perl
+
+use warnings;
+use strict;
+use IO::Socket;
+use Storable qw(thaw);
+use constant MY_ECHO_PORT => 2007;
+use constant MAX_MSG_LEN => 5000;
+
+my $port = shift || MY_ECHO_PORT;
+
+$SIG{INT} = sub { exit 0 };
+
+my $sock = IO::Socket::INET->new(Proto => 'udp', LocalPort => $port) or die $@;
+
+my $msg_in;
+
+warn "servicing incoming requests...\n";
+
+while(1) {
+
+    next unless $sock->recv($msg_in, MAX_MSG_LEN);
+    my $status_ref = thaw($msg_in);
+    my $peer_host = gethostbyaddr($sock->peeraddr, AF_INET) || $sock->peerhost;
+    my $peer_port = $sock->peerport;
+    my $length = length($msg_in);
+
+    my ($curr_dists, $total_dists, $dps) = ( $status_ref->{curr_dists},$status_ref->{total_dists},$status_ref->{dps} );
+
+    print '+----------------------------------------+', "\n";
+    print 'CPAN::Reporter::Smoker quick stats:', "\n";
+    print "Received $length bytes from [$peer_host, $peer_port]\n";
+    print "Doing $curr_dists of $total_dists ($dps)\n";
+
+    #$msg_out = reverse $msg_in;
+    #$sock->send($msg_out) or die "send(): $!\n";
+
+}
+
+$sock->close;


### PR DESCRIPTION
After this modification it is possible to:
- if the ```start()``` method of CPAN::Reporter::Smoker receives a parameter ```stats_file => '/some/path'```, a CSV file will be created in this location. The CSV will have elapsed time of indexing and of each distribution tested.
- after each distribution tested, CPAN::Reporter::Smoker will also connect to a UDP server and send the current number of tested distribution, the total number of distributions to be tested and the number of distributions tested per minute. The smoker will not check if the datagram sent was received or not, so it's safe to leave the smoker running without the monitor.
- to configure the online monitor, check the ```start()``` parameters ```rep_addr``` and ```rep_port```. The script show_progress.pl (that implements the UDP server) also have the options ```-p``` and ```-l``` for the same configuration. Default values are available for both script and module (localhost and 2007).