### PR TITLE
adjust tests to CPAN 2.29+

### DIFF
--- a/t/CPAN/authors/id/A/AN/ANDK/CHECKSUMS
+++ b/t/CPAN/authors/id/A/AN/ANDK/CHECKSUMS
@@ -1,6 +1,7 @@
 # CHECKSUMS file written on Mon Jan 28 13:21:04 2008 GMT by CPAN::Checksums (v1.064)
 $cksum = {
   'Bogus-OSUnsupported-0.01.tar.gz' => {
+    'cpan_path' => 'A/AN/ANDK',
     'md5' => '1e054a7da63e22a7b5acb98baaa47eb3',
     'md5-ungz' => '8cf33a880347adb0376b7ab6b5a16dff',
     'mtime' => '2008-01-27',

--- a/t/CPAN/authors/id/D/DA/DAGOLDEN/CHECKSUMS
+++ b/t/CPAN/authors/id/D/DA/DAGOLDEN/CHECKSUMS
@@ -1,6 +1,7 @@
 # CHECKSUMS file written on Wed Feb 13 03:44:01 2008 GMT by CPAN::Checksums (v1.064)
 $cksum = {
   'Bogus-Fail-0.01.tar.gz' => {
+    'cpan_path' => 'D/DA/DAGOLDEN',
     'md5' => 'e5967bcb6cb23987db704607fda283b3',
     'md5-ungz' => 'e8c5a6e36636aec8b19b115020026f13',
     'mtime' => '2008-01-27',
@@ -9,6 +10,7 @@ $cksum = {
     'size' => 965
   },
   'Bogus-PL-Fail-0.01.tar.gz' => {
+    'cpan_path' => 'D/DA/DAGOLDEN',
     'md5' => 'a60f2751456efa0e787e9d2b143d1ccc',
     'md5-ungz' => '70580f04a8db2ee4b2fd50614cb38f19',
     'mtime' => '2008-01-27',
@@ -17,6 +19,7 @@ $cksum = {
     'size' => 1007
   },
   'Bogus-Pass-0.01.tar.gz' => {
+    'cpan_path' => 'D/DA/DAGOLDEN',
     'md5' => '6a208561a1c455dfce11ca7a446f4eb9',
     'md5-ungz' => 'ef5b052ce8d8ffc29107a99d0e79016c',
     'mtime' => '2008-01-27',
@@ -25,6 +28,7 @@ $cksum = {
     'size' => 962
   },
   'Bundle-Fake-1.00.tar.gz' => {
+    'cpan_path' => 'D/DA/DAGOLDEN',
     'md5' => '2685146a32c45b6c0fee2dd8807cad68',
     'md5-ungz' => 'ca55cef7ab32536681f5056124570b9c',
     'mtime' => '2008-02-13',

--- a/t/CPAN/authors/id/J/JH/JHI/CHECKSUMS
+++ b/t/CPAN/authors/id/J/JH/JHI/CHECKSUMS
@@ -1,6 +1,7 @@
 # CHECKSUMS file written on Wed Feb 13 03:44:01 2008 GMT by CPAN::Checksums (v1.064)
 $cksum = {
   'Bogus-Fail-0.01_01.tar.gz' => {
+    'cpan_path' => 'J/JH/JHI',
     'md5' => 'd59a04393812e66619686c84f1aab7fa',
     'md5-ungz' => 'eab1658ad451035b75667243987e841a',
     'mtime' => '2008-02-04',

--- a/t/CPAN/authors/id/P/P6/P6DISTS/Perl6/CHECKSUMS
+++ b/t/CPAN/authors/id/P/P6/P6DISTS/Perl6/CHECKSUMS
@@ -1,6 +1,7 @@
 # CHECKSUMS file written on Mon Feb  4 15:50:30 2008 GMT by CPAN::Checksums (v1.064)
 $cksum = {
   'Perl6/Test-Harness-666.tar.gz' => {
+    'cpan_path' => 'P/P6/P6DISTS',
     'md5' => '4e62bf6e872ffa5eae6ce1dd2cc45a6e',
     'md5-ungz' => '74f91dc11e218373a467d80df5a483ef',
     'mtime' => '2008-02-04',

--- a/t/CPAN/authors/id/P/PE/PETDANCE/CHECKSUMS
+++ b/t/CPAN/authors/id/P/PE/PETDANCE/CHECKSUMS
@@ -1,6 +1,7 @@
 # CHECKSUMS file written on Mon Feb  4 15:50:30 2008 GMT by CPAN::Checksums (v1.064)
 $cksum = {
   'Test-Harness-2.62.tar.gz' => {
+    'cpan_path' => 'P/PE/PETDANCE',
     'md5' => '4e62bf6e872ffa5eae6ce1dd2cc45a6e',
     'md5-ungz' => '74f91dc11e218373a467d80df5a483ef',
     'mtime' => '2008-02-04',

--- a/t/data/MyConfig.pm
+++ b/t/data/MyConfig.pm
@@ -54,6 +54,7 @@ $CPAN::Config = {
                  'urllist' => [qq[file://$cwd/t/CPAN]],
                  'wait_list' => [q[wait://ls6.informatik.uni-dortmund.de:1404]],
                  #'wget' => q[/usr/bin/wget],
+                 'pushy_https' => 0,
                 };
 
 __END__


### PR DESCRIPTION

In Debian we are currently applying the following patch to
CPAN-Reporter-Smoker.
We thought you might be interested in it too.

    Description: adjust tests to CPAN 2.29+
     1) set pushy_https => 0 in MyConfig.pm, otherwise urllist is ignored as unsafe
     2) add cpan_path keys to CHECKSUM files, otherwise CPAN.pm aborts
    Origin: vendor
    Bug-Debian: https://bugs.debian.org/1014293
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2022-07-03
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libcpan-reporter-smoker-perl/raw/master/debian/patches/CPAN.pm_2.29.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
